### PR TITLE
fix: set correct access level for publish action

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
         "url": "https://github.com/Dintero/sri-to-dist/issues"
     },
     "private": false,
+    "publishConfig": {
+      "access": "public"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/Dintero/sri-to-dist.git"


### PR DESCRIPTION
Ref. https://github.com/Dintero/sri-to-dist/actions/runs/14311907288/job/40108741349
Ref. https://semantic-release.gitbook.io/semantic-release/support/faq#how-can-i-set-the-access-level-of-the-published-npm-package

Error caused by: Scoped packages require organizational accounts unless explicitly marked as public during publishing.