### PR TITLE
fix:Add rootDir to tsconfig for correct path in dist folder

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,11 +27,12 @@
 
         /* Modules */
         "module": "NodeNext" /* Specify what module code is generated. */,
-        // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+        "rootDir": "./src",                                  /* Specify the root folder within your source files. */
         "moduleResolution": "NodeNext" /* Specify how TypeScript looks up a file from a given module specifier. */,
         // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
         // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-        // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+        // "rootDirs": [],
+        //                                    /* Allow multiple folders to be treated as one when resolving modules. */
         // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
         // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
         // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
@@ -111,5 +112,5 @@
         "skipLibCheck": true /* Skip type checking all .d.ts files. */
     },
     "include": ["src/**/*"],
-    "exclude": ["node_modules", "**/*.test.ts", "dist"]
+    "exclude": ["node_modules", "**/*.test.ts", "dist"],
 }


### PR DESCRIPTION
Fixes broken functionality in npm bundle, wrong file-structure in dist folder, fixed by setting `rootDir` in tsconfig.


Without `rootDir` we have this file structure.
```
❯ tree node_modules/@dintero/sri-to-dist
node_modules/@dintero/sri-to-dist
├── LICENSE
├── README.md
├── bin
│   └── sri-to-dist.js
├── dist
│   ├── package.json
│   └── src
│       ├── index.d.ts
│       ├── index.js
│       ├── lib.d.ts
│       └── lib.js
└── package.json

4 directories, 9 files
```

Causing this error
```
$ sri-to-dist --input dist/index.html
node:internal/modules/cjs/loader:1252
  throw err;

Error: Cannot find module '../dist/index.js'
```

